### PR TITLE
feat: Add TabController

### DIFF
--- a/fe/lib/main.dart
+++ b/fe/lib/main.dart
@@ -17,7 +17,24 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
+
+  late TabController _tabController;               // Enable tabs scroll horizontally
+
+  @override
+  // Called when widget is created
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 7, vsync: this);      // Create TabController, specify number of tabs: 7 tabs
+  }
+
+  @override
+  // Called when widget is completely terminated
+  void dispose() {
+  _tabController.dispose();
+  super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -36,6 +53,8 @@ class _MyAppState extends State<MyApp> {
         body: Column(
           children: [
             TabBar(                                 // TabBar: 7 tabs
+              controller: _tabController,
+              isScrollable: true,
               // design property
               indicatorColor: Color(0xff4C7A7E),
               labelStyle: TextStyle(fontWeight: FontWeight.bold),
@@ -53,6 +72,7 @@ class _MyAppState extends State<MyApp> {
             Expanded(
               child:
               TabBarView(
+                controller: _tabController,
                 children: [
                   Center(child: Text('전체 탭')),      // Tab1: "전체"
                   Center(child: Text('정치 탭')),      // Tab2: "정치"


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✅] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fe/develop-> main

### 변경 사항
모바일 기기에서 화면 너비에 비해 tab의 개수가 많아 텍스트가 잘리는 문제가 있었습니다. 
그래서 tab을 가로로 스크롤할 수 있도록 tabController를 추가해 해당 문제를 해결했습니다.

### 테스트 결과
<img width="334" alt="스크린샷 2023-10-22 오후 5 54 24" src="https://github.com/qndn3tp/WhatsIn/assets/84118129/24ea8a7e-3edd-41b6-8707-e7bf2dc933f0">
<img width="332" alt="스크린샷 2023-10-22 오후 5 54 18" src="https://github.com/qndn3tp/WhatsIn/assets/84118129/d3b98abc-39b7-4f56-8046-d605c3a68849">
tab을 가로로 스크롤할 수 있습니다.